### PR TITLE
Lab1: RPC and Method Naming + Process ID Feature

### DIFF
--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -30,23 +30,24 @@ const (
 	Exit
 )
 
-type AssignTaskArgs struct {
+type RequestTaskArgs struct {
+	WorkerId int
 }
 
-type AssignTaskReply struct {
+type RequestTaskReply struct {
 	Type       TaskType
 	TaskNumber int
 	InputFiles []string
 	NReduce    int
 }
 
-type MarkCompleteArgs struct {
-	Type        TaskType
-	TaskNumber  int
-	OutputFiles []string
+type ReportTaskCompleteArgs struct {
+	Type       TaskType
+	TaskNumber int
+	WorkerId   int
 }
 
-type MarkCompleteReply struct {
+type ReportTaskCompleteReply struct {
 }
 
 // Cook up a unique-ish UNIX-domain socket name


### PR DESCRIPTION
- Add process ID to RPCs + waitForTaskRes logic
- Change names of internal methods to lower camel case
- Split completion channels -> map and reduce channels
- Decrement down from nTasksLeft
- Change naming of available task channel to taskQueue
- Other things that i probably missed here