### PR TITLE
Atomic Status Counters

### DIFF
--- a/src/main/run-wc.sh
+++ b/src/main/run-wc.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#
+# Runs map reduce word count
+#
+echo '***' Starting MapReduce with wc.so.
+rm -f mr-*
+
+TIMEOUT=timeout
+TIMEOUT+=" -k 2s 180s "
+
+$TIMEOUT ../mrcoordinator ../pg*txt &
+pid=$!
+
+# give the coordinator time to create the sockets.
+sleep 1
+
+# start multiple workers.
+$TIMEOUT ../mrworker ../../mrapps/wc.so &
+$TIMEOUT ../mrworker ../../mrapps/wc.so &
+$TIMEOUT ../mrworker ../../mrapps/wc.so &
+$TIMEOUT ../mrworker ../../mrapps/wc.so &
+$TIMEOUT ../mrworker ../../mrapps/wc.so &
+
+# wait for the coordinator to exit.
+wait $pid

--- a/src/main/time-wc.sh
+++ b/src/main/time-wc.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# run the test in a fresh sub-directory.
+echo "Timing MapReduce with Word Count"
+rm -rf mr-tmp
+mkdir mr-tmp || exit 1
+cd mr-tmp || exit 1
+rm -f mr-*
+echo "Setting up output directory: $(pwd)"
+
+# Build wc, coordinator, and worker
+echo "Building apps..."
+(cd ../../mrapps && go build $RACE -buildmode=plugin wc.go) || exit 1
+(cd .. && go build $RACE mrcoordinator.go) || exit 1
+(cd .. && go build $RACE mrworker.go) || exit 1
+
+hyperfine -w 3 'timeout -k 2s 900s ../run-wc.sh' &
+pid=$!
+wait $pid

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -203,7 +203,7 @@ func (c *Coordinator) RequestTask(args *RequestTaskArgs, reply *RequestTaskReply
 		if c.changeTaskStatus(reply.Type, reply.TaskNumber, Unscheduled, Running) {
 			go c.waitForTaskAtomics(reply.Type, reply.TaskNumber)
 		} else {
-			fmt.Printf("Invariant broken. Failed state change in RequestTask.")
+			log.Fatal("Invariant broken with failed state change in RequestTask. Exit...")
 		}
 	}
 	return nil

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -167,7 +167,7 @@ func (c *Coordinator) changeTaskStatus(taskType TaskType, taskNumber int, oldSta
 	case Reduce:
 		status = c.reduceTaskStatus
 	default:
-		fmt.Printf("Received unknown type %v in changeTaskStatus.\n", taskType)
+		fmt.Printf("Received unexpected type %v in changeTaskStatus.\n", taskType)
 		return false
 	}
 	return atomic.CompareAndSwapInt32(&status[taskNumber], int32(oldState), int32(newState))

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -96,7 +96,11 @@ func (c *Coordinator) waitForTaskResult(taskType TaskType, taskNumber int, assig
 		select {
 		case workerId := <-c.getTaskChannel(taskType, taskNumber):
 			if workerId != assignedWorker {
-				continue
+				fmt.Printf(
+					"Received a different worker %v instead of %v. Continue anyway (idempotent!)...\n",
+					workerId,
+					assignedWorker,
+				)
 			}
 			fmt.Printf("Task %v completion notified on worker %v\n", taskNumber, assignedWorker)
 			tasksLeft := atomic.AddInt32(&c.nTasksLeft, -1)

--- a/src/mr/rpc.go
+++ b/src/mr/rpc.go
@@ -9,19 +9,6 @@ package mr
 import "os"
 import "strconv"
 
-//
-// example to show how to declare the arguments
-// and reply for an RPC.
-//
-
-type ExampleArgs struct {
-	X int
-}
-
-type ExampleReply struct {
-	Y int
-}
-
 type TaskType uint8
 
 const (
@@ -41,13 +28,13 @@ type RequestTaskReply struct {
 	NReduce    int
 }
 
-type ReportTaskCompleteArgs struct {
+type ReportTaskResultArgs struct {
 	Type       TaskType
 	TaskNumber int
 	WorkerId   int
 }
 
-type ReportTaskCompleteReply struct {
+type ReportTaskResultReply struct {
 }
 
 // Cook up a unique-ish UNIX-domain socket name

--- a/src/mr/worker.go
+++ b/src/mr/worker.go
@@ -43,10 +43,10 @@ func Worker(mapf func(string, string) []KeyValue,
 		switch reply.Type {
 		case Map:
 			ApplyMap(mapf, reply.InputFiles[0], reply.NReduce, reply.TaskNumber)
-			CallReportTaskComplete(reply.Type, reply.TaskNumber)
+			CallReportTaskResult(reply.Type, reply.TaskNumber)
 		case Reduce:
 			ApplyReduce(reducef, reply.InputFiles, reply.TaskNumber)
-			CallReportTaskComplete(reply.Type, reply.TaskNumber)
+			CallReportTaskResult(reply.Type, reply.TaskNumber)
 		default:
 			fmt.Printf("Breaking worker loop...\n")
 			breakLoop = true
@@ -161,10 +161,10 @@ func CallRequestTask() *RequestTaskReply {
 	return &reply
 }
 
-func CallReportTaskComplete(taskType TaskType, number int) ReportTaskCompleteReply {
-	args := ReportTaskCompleteArgs{Type: taskType, TaskNumber: number, WorkerId: os.Getpid()}
-	reply := ReportTaskCompleteReply{}
-	ok := call("Coordinator.ReportTaskComplete", &args, &reply)
+func CallReportTaskResult(taskType TaskType, number int) ReportTaskResultReply {
+	args := ReportTaskResultArgs{Type: taskType, TaskNumber: number, WorkerId: os.Getpid()}
+	reply := ReportTaskResultReply{}
+	ok := call("Coordinator.ReportTaskResult", &args, &reply)
 	if !ok {
 		fmt.Printf("call failed!\n")
 	}


### PR DESCRIPTION
Rather than using channels to communicate when a task is done from RPC handler to another goroutine, we track each task's status as a separate atomic integer, which can only undergo 3 state changes:
0 -> 1: when scheduled/assigned to a worker
1 -> 2: when finished
1 -> 0: when task has timed out and needs to be rescheduled

We can enforce only these state changes with CompareAndSwap.